### PR TITLE
article-mushroom-likes

### DIFF
--- a/BackendFungi/Abstractions/Repositories/IArticleLikesRepository.cs
+++ b/BackendFungi/Abstractions/Repositories/IArticleLikesRepository.cs
@@ -1,0 +1,8 @@
+namespace BackendFungi.Abstractions.Repositories;
+
+public interface  IArticleLikesRepository
+{
+    Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct);
+    Task<int> GetLikesCountAsync(Guid articleId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct);
+}

--- a/BackendFungi/Abstractions/Repositories/IMushroomLikesRepository.cs
+++ b/BackendFungi/Abstractions/Repositories/IMushroomLikesRepository.cs
@@ -1,0 +1,8 @@
+namespace BackendFungi.Abstractions.Repositories;
+
+public interface IMushroomLikesRepository
+{
+    Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+    Task<int> GetLikesCountAsync(Guid mushroomId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+}

--- a/BackendFungi/Abstractions/Services/IArticleLikesService.cs
+++ b/BackendFungi/Abstractions/Services/IArticleLikesService.cs
@@ -1,0 +1,8 @@
+namespace BackendFungi.Abstractions.Services;
+
+public interface IArticleLikesService
+{
+    Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct);
+    Task<int> GetLikesCountAsync(Guid articleId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct);
+}

--- a/BackendFungi/Abstractions/Services/IArticleLikesService.cs
+++ b/BackendFungi/Abstractions/Services/IArticleLikesService.cs
@@ -1,8 +1,10 @@
+using System.Security.Claims;
+
 namespace BackendFungi.Abstractions.Services;
 
 public interface IArticleLikesService
 {
-    Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct);
+    Task<bool> ToggleLikeAsync(Guid articleId, ClaimsPrincipal user, CancellationToken ct);
     Task<int> GetLikesCountAsync(Guid articleId, CancellationToken ct);
-    Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid articleId, ClaimsPrincipal user, CancellationToken ct);
 }

--- a/BackendFungi/Abstractions/Services/IMushroomLikesService.cs
+++ b/BackendFungi/Abstractions/Services/IMushroomLikesService.cs
@@ -1,0 +1,8 @@
+namespace BackendFungi.Abstractions.Services;
+
+public interface IMushroomLikesService
+{
+    Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+    Task<int> GetLikesCountAsync(Guid mushroomId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+}

--- a/BackendFungi/Abstractions/Services/IMushroomLikesService.cs
+++ b/BackendFungi/Abstractions/Services/IMushroomLikesService.cs
@@ -1,8 +1,10 @@
+using System.Security.Claims;
+
 namespace BackendFungi.Abstractions.Services;
 
 public interface IMushroomLikesService
 {
-    Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+    Task<bool> ToggleLikeAsync(Guid mushroomId, ClaimsPrincipal user, CancellationToken ct);
     Task<int> GetLikesCountAsync(Guid mushroomId, CancellationToken ct);
-    Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct);
+    Task<bool> HasUserLikedAsync(Guid mushroomId, ClaimsPrincipal user, CancellationToken ct);
 }

--- a/BackendFungi/BackendFungi.csproj
+++ b/BackendFungi/BackendFungi.csproj
@@ -22,7 +22,6 @@
 
     <ItemGroup>
       <Folder Include="Database\Context\" />
-      <Folder Include="Database\Entities\" />
     </ItemGroup>
 
 </Project>

--- a/BackendFungi/Controllers/ArticleLikesController.cs
+++ b/BackendFungi/Controllers/ArticleLikesController.cs
@@ -1,0 +1,40 @@
+using BackendFungi.Abstractions.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BackendFungi.Controllers;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class ArticleLikesController : ControllerBase
+{
+    private readonly IArticleLikesService _likesService;
+
+    public ArticleLikesController(IArticleLikesService likesService)
+    {
+        _likesService = likesService;
+    }
+
+    [HttpPost]
+    [Authorize]
+    public async Task<IActionResult> ToggleLike(Guid articleId, CancellationToken ct)
+    {
+        var result = await _likesService.ToggleLikeAsync(articleId, User, ct);
+        return Ok(new { IsLiked = result });
+    }
+
+    [HttpGet("count")]
+    public async Task<IActionResult> GetLikesCount(Guid articleId, CancellationToken ct)
+    {
+        var count = await _likesService.GetLikesCountAsync(articleId, ct);
+        return Ok(new { Count = count });
+    }
+
+    [HttpGet("user")]
+    [Authorize]
+    public async Task<IActionResult> HasUserLiked(Guid articleId, CancellationToken ct)
+    {
+        var hasLiked = await _likesService.HasUserLikedAsync(articleId, User, ct);
+        return Ok(new { HasLiked = hasLiked });
+    }
+}

--- a/BackendFungi/Controllers/MushroomLikesController.cs
+++ b/BackendFungi/Controllers/MushroomLikesController.cs
@@ -1,0 +1,39 @@
+using BackendFungi.Abstractions.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BackendFungi.Controllers;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class MushroomLikesController : ControllerBase
+{
+    private readonly IMushroomLikesService _likesService;
+
+    public MushroomLikesController(IMushroomLikesService likesService)
+    {
+        _likesService = likesService;
+    }
+
+    [HttpPost]
+    [Authorize]
+    public async Task<IActionResult> ToggleLike(Guid mushroomId, CancellationToken ct)
+    {
+        var result = await _likesService.ToggleLikeAsync(mushroomId, User, ct);
+        return Ok(new { IsLiked = result });
+    }
+
+    [HttpGet("count")]
+    public async Task<IActionResult> GetLikesCount(Guid mushroomId, CancellationToken ct)
+    {
+        var count = await _likesService.GetLikesCountAsync(mushroomId, ct);
+        return Ok(new { Count = count });
+    }
+
+    [HttpGet("user")]
+    public async Task<IActionResult> HasUserLiked(Guid mushroomId, CancellationToken ct)
+    {
+        var hasLiked = await _likesService.HasUserLikedAsync(mushroomId, User, ct);
+        return Ok(new { HasLiked = hasLiked });
+    }
+}

--- a/BackendFungi/Database/Context/FungiDbContext.cs
+++ b/BackendFungi/Database/Context/FungiDbContext.cs
@@ -24,6 +24,8 @@ public partial class FungiDbContext : DbContext
     public virtual DbSet<Paragraph> Paragraphs { get; set; }
     public virtual DbSet<Role> Roles { get; set; }
     public virtual DbSet<User> Users { get; set; }
+    public virtual DbSet<ArticleLike> ArticleLikes { get; set; }
+    public virtual DbSet<MushroomLike> MushroomLikes { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -106,6 +108,50 @@ public partial class FungiDbContext : DbContext
                 .HasForeignKey(d => d.RoleId)
                 .OnDelete(DeleteBehavior.Restrict)
                 .HasConstraintName("Users_RoleId_fkey");
+        });
+        
+        modelBuilder.Entity<ArticleLike>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("ArticleLikes_pkey");
+            entity.HasIndex(e => e.ArticleId, "fki_ArticleLikes_ArticleId_fkey");
+            entity.HasIndex(e => e.UserId, "fki_ArticleLikes_UserId_fkey");
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        
+            entity.HasOne(d => d.Article)
+                .WithMany()
+                .HasForeignKey(d => d.ArticleId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("ArticleLikes_ArticleId_fkey");
+            
+            entity.HasOne(d => d.User)
+                .WithMany()
+                .HasForeignKey(d => d.UserId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("ArticleLikes_UserId_fkey");
+            
+            entity.HasIndex(e => new { e.ArticleId, e.UserId }, "article_likes_unique_user_article").IsUnique();
+        });
+
+        modelBuilder.Entity<MushroomLike>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("MushroomLikes_pkey");
+            entity.HasIndex(e => e.MushroomId, "fki_MushroomLikes_MushroomId_fkey");
+            entity.HasIndex(e => e.UserId, "fki_MushroomLikes_UserId_fkey");
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        
+            entity.HasOne(d => d.Mushroom)
+                .WithMany()
+                .HasForeignKey(d => d.MushroomId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("MushroomLikes_MushroomId_fkey");
+            
+            entity.HasOne(d => d.User)
+                .WithMany()
+                .HasForeignKey(d => d.UserId)
+                .OnDelete(DeleteBehavior.Cascade)
+                .HasConstraintName("MushroomLikes_UserId_fkey");
+            
+            entity.HasIndex(e => new { e.MushroomId, e.UserId }, "mushroom_likes_unique_user_mushroom").IsUnique();
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/BackendFungi/Database/Entities/ArticleLike.cs
+++ b/BackendFungi/Database/Entities/ArticleLike.cs
@@ -1,0 +1,12 @@
+namespace BackendFungi.Database.Entities;
+
+public class ArticleLike
+{
+    public Guid Id { get; set; }
+    public Guid ArticleId { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime LikeDate { get; set; }
+    
+    public virtual Article Article { get; set; }
+    public virtual User User { get; set; }
+}

--- a/BackendFungi/Database/Entities/MushroomLike.cs
+++ b/BackendFungi/Database/Entities/MushroomLike.cs
@@ -1,0 +1,12 @@
+namespace BackendFungi.Database.Entities;
+
+public class MushroomLike
+{
+    public Guid Id { get; set; }
+    public Guid MushroomId { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime LikeDate { get; set; }
+    
+    public virtual Mushroom Mushroom { get; set; }
+    public virtual User User { get; set; }
+}

--- a/BackendFungi/Program.cs
+++ b/BackendFungi/Program.cs
@@ -60,12 +60,16 @@ builder.Services.AddScoped<IArticlesService, ArticlesService>();
 builder.Services.AddScoped<IMushroomsService, MushroomsService>();
 builder.Services.AddScoped<IRolesService, RolesService>();
 builder.Services.AddScoped<IUsersService, UsersService>();
+builder.Services.AddScoped<IArticleLikesService, ArticleLikesService>();
+builder.Services.AddScoped<IMushroomLikesService, MushroomLikesService>();
 
 // Services for repositories
 builder.Services.AddScoped<IArticlesRepository, ArticlesRepository>();
 builder.Services.AddScoped<IMushroomsRepository, MushroomsRepository>();
 builder.Services.AddScoped<IRolesRepository, RolesRepository>();
 builder.Services.AddScoped<IUsersRepository, UsersRepository>();
+builder.Services.AddScoped<IArticleLikesRepository, ArticleLikesRepository>();
+builder.Services.AddScoped<IMushroomLikesRepository, MushroomLikesRepository>();
 
 // Service for correct response data wrapping
 builder.Services.AddSingleton<IActionResultExecutor<ObjectResult>, CustomObjectResultExecutor>();

--- a/BackendFungi/Repositories/ArticleLikesRepository.cs
+++ b/BackendFungi/Repositories/ArticleLikesRepository.cs
@@ -1,0 +1,53 @@
+using BackendFungi.Abstractions.Repositories;
+using BackendFungi.Database.Context;
+using BackendFungi.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BackendFungi.Repositories;
+
+public class ArticleLikesRepository : IArticleLikesRepository
+{
+    private readonly FungiDbContext _context;
+
+    public ArticleLikesRepository(FungiDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct)
+    {
+        var existingLike = await _context.ArticleLikes
+            .FirstOrDefaultAsync(x => x.ArticleId == articleId && x.UserId == userId, ct);
+
+        if (existingLike != null)
+        {
+            _context.ArticleLikes.Remove(existingLike);
+            await _context.SaveChangesAsync(ct);
+            return false;
+        }
+
+        var newLike = new ArticleLike
+        {
+            Id = Guid.NewGuid(),
+            ArticleId = articleId,
+            UserId = userId,
+            LikeDate = DateTime.UtcNow
+        };
+
+        await _context.ArticleLikes.AddAsync(newLike, ct);
+        await _context.SaveChangesAsync(ct);
+        return true; 
+    }
+
+    public async Task<int> GetLikesCountAsync(Guid articleId, CancellationToken ct)
+    {
+        return await _context.ArticleLikes
+            .CountAsync(x => x.ArticleId == articleId, ct);
+    }
+
+    public async Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct)
+    {
+        return await _context.ArticleLikes
+            .AnyAsync(x => x.ArticleId == articleId && x.UserId == userId, ct);
+    }
+}

--- a/BackendFungi/Repositories/MushroomLikesRepository.cs
+++ b/BackendFungi/Repositories/MushroomLikesRepository.cs
@@ -1,0 +1,53 @@
+using BackendFungi.Abstractions.Repositories;
+using BackendFungi.Database.Context;
+using BackendFungi.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BackendFungi.Repositories;
+
+public class MushroomLikesRepository : IMushroomLikesRepository
+{
+    private readonly FungiDbContext _context;
+
+    public MushroomLikesRepository(FungiDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    {
+        var existingLike = await _context.MushroomLikes
+            .FirstOrDefaultAsync(x => x.MushroomId == mushroomId && x.UserId == userId, ct);
+
+        if (existingLike != null)
+        {
+            _context.MushroomLikes.Remove(existingLike);
+            await _context.SaveChangesAsync(ct);
+            return false;
+        }
+
+        var newLike = new MushroomLike
+        {
+            Id = Guid.NewGuid(),
+            MushroomId = mushroomId,
+            UserId = userId,
+            LikeDate = DateTime.UtcNow
+        };
+
+        await _context.MushroomLikes.AddAsync(newLike, ct);
+        await _context.SaveChangesAsync(ct);
+        return true; 
+    }
+
+    public async Task<int> GetLikesCountAsync(Guid mushroomId, CancellationToken ct)
+    {
+        return await _context.MushroomLikes
+            .CountAsync(x => x.MushroomId == mushroomId, ct);
+    }
+
+    public async Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    {
+        return await _context.MushroomLikes
+            .AnyAsync(x => x.MushroomId == mushroomId && x.UserId == userId, ct);
+    }
+}

--- a/BackendFungi/Services/ArticleLikesService.cs
+++ b/BackendFungi/Services/ArticleLikesService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using BackendFungi.Abstractions.Repositories;
 using BackendFungi.Abstractions.Services;
 
@@ -12,8 +13,9 @@ public class ArticleLikesService : IArticleLikesService
         _likesRepository = likesRepository;
     }
 
-    public async Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct)
+    public async Task<bool> ToggleLikeAsync(Guid articleId, ClaimsPrincipal user, CancellationToken ct)
     {
+        var userId = GetUserId(user);
         return await _likesRepository.ToggleLikeAsync(articleId, userId, ct);
     }
 
@@ -22,8 +24,14 @@ public class ArticleLikesService : IArticleLikesService
         return await _likesRepository.GetLikesCountAsync(articleId, ct);
     }
 
-    public async Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct)
+    public async Task<bool> HasUserLikedAsync(Guid articleId, ClaimsPrincipal user, CancellationToken ct)
     {
+        var userId = GetUserId(user);
         return await _likesRepository.HasUserLikedAsync(articleId, userId, ct);
+    }
+
+    private static Guid GetUserId(ClaimsPrincipal user)
+    {
+        return Guid.Parse(user.FindFirst("UserId")?.Value ?? throw new UnauthorizedAccessException());
     }
 }

--- a/BackendFungi/Services/ArticleLikesService.cs
+++ b/BackendFungi/Services/ArticleLikesService.cs
@@ -1,0 +1,29 @@
+using BackendFungi.Abstractions.Repositories;
+using BackendFungi.Abstractions.Services;
+
+namespace BackendFungi.Services;
+
+public class ArticleLikesService : IArticleLikesService
+{
+    private readonly IArticleLikesRepository _likesRepository;
+
+    public ArticleLikesService(IArticleLikesRepository likesRepository)
+    {
+        _likesRepository = likesRepository;
+    }
+
+    public async Task<bool> ToggleLikeAsync(Guid articleId, Guid userId, CancellationToken ct)
+    {
+        return await _likesRepository.ToggleLikeAsync(articleId, userId, ct);
+    }
+
+    public async Task<int> GetLikesCountAsync(Guid articleId, CancellationToken ct)
+    {
+        return await _likesRepository.GetLikesCountAsync(articleId, ct);
+    }
+
+    public async Task<bool> HasUserLikedAsync(Guid articleId, Guid userId, CancellationToken ct)
+    {
+        return await _likesRepository.HasUserLikedAsync(articleId, userId, ct);
+    }
+}

--- a/BackendFungi/Services/MushroomLikesService.cs
+++ b/BackendFungi/Services/MushroomLikesService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using BackendFungi.Abstractions.Repositories;
 using BackendFungi.Abstractions.Services;
 
@@ -12,8 +13,9 @@ public class MushroomLikesService : IMushroomLikesService
         _likesRepository = likesRepository;
     }
 
-    public async Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    public async Task<bool> ToggleLikeAsync(Guid mushroomId, ClaimsPrincipal user, CancellationToken ct)
     {
+        var userId = GetUserId(user);
         return await _likesRepository.ToggleLikeAsync(mushroomId, userId, ct);
     }
 
@@ -22,8 +24,14 @@ public class MushroomLikesService : IMushroomLikesService
         return await _likesRepository.GetLikesCountAsync(mushroomId, ct);
     }
 
-    public async Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    public async Task<bool> HasUserLikedAsync(Guid mushroomId, ClaimsPrincipal user, CancellationToken ct)
     {
+        var userId = GetUserId(user);
         return await _likesRepository.HasUserLikedAsync(mushroomId, userId, ct);
+    }
+    
+    private static Guid GetUserId(ClaimsPrincipal user)
+    {
+        return Guid.Parse(user.FindFirst("UserId")?.Value ?? throw new UnauthorizedAccessException());
     }
 }

--- a/BackendFungi/Services/MushroomLikesService.cs
+++ b/BackendFungi/Services/MushroomLikesService.cs
@@ -1,0 +1,29 @@
+using BackendFungi.Abstractions.Repositories;
+using BackendFungi.Abstractions.Services;
+
+namespace BackendFungi.Services;
+
+public class MushroomLikesService : IMushroomLikesService
+{
+    private readonly IMushroomLikesRepository _likesRepository;
+
+    public MushroomLikesService(IMushroomLikesRepository likesRepository)
+    {
+        _likesRepository = likesRepository;
+    }
+
+    public async Task<bool> ToggleLikeAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    {
+        return await _likesRepository.ToggleLikeAsync(mushroomId, userId, ct);
+    }
+
+    public async Task<int> GetLikesCountAsync(Guid mushroomId, CancellationToken ct)
+    {
+        return await _likesRepository.GetLikesCountAsync(mushroomId, ct);
+    }
+
+    public async Task<bool> HasUserLikedAsync(Guid mushroomId, Guid userId, CancellationToken ct)
+    {
+        return await _likesRepository.HasUserLikedAsync(mushroomId, userId, ct);
+    }
+}

--- a/BackendFungi/appsettings.Development.json
+++ b/BackendFungi/appsettings.Development.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "FungiDbContext": "Host=fungi-db;Port=5531;Database=FungiDB;Username=fungi;Password=fungi"
+    "FungiDbContext": "Host=localhost;Port=5531;Database=FungiDB;Username=fungi;Password=fungi"
   },
   "Jwt": {
     "Key": "Very_strong_and_super_super_secret_key_123!",

--- a/BackendFungi/appsettings.json
+++ b/BackendFungi/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "FungiDbContext": "Host=localhost;Port=5454;Database=FungiDB;Username=postgres;Password=admin"
+    "FungiDbContext": "Host=localhost;Port=5531;Database=FungiDB;Username=fungi;Password=fungi"
   },
   "Jwt": {
     "Key": "Very_strong_and_super_super_secret_key_123!",

--- a/DBInit/0-db-init.sql
+++ b/DBInit/0-db-init.sql
@@ -70,7 +70,7 @@ CREATE TABLE public."Doppelgangers" (
 CREATE INDEX "fki_Doppelgangers_MushroomId_fkey" ON public."Doppelgangers" USING btree ("MushroomId");
 
 CREATE TABLE public."ArticleLikes" (
-  "Id" serial primary key,
+  "Id" uuid PRIMARY KEY NOT NULL,
   "ArticleId" uuid NOT NULL REFERENCES public."Articles" ("Id") ON DELETE CASCADE,
   "UserId" uuid NOT NULL REFERENCES public."Users" ("Id") ON DELETE CASCADE,
   "LikeDate" timestamp with time zone NOT NULL DEFAULT now(),
@@ -78,7 +78,7 @@ CREATE TABLE public."ArticleLikes" (
 );
 
 CREATE TABLE public."MushroomLikes" (
-  "Id" serial primary key,
+  "Id" uuid PRIMARY KEY NOT NULL,
   "MushroomId" uuid NOT NULL REFERENCES public."Mushrooms" ("Id") ON DELETE CASCADE,
   "UserId" uuid NOT NULL REFERENCES public."Users" ("Id") ON DELETE CASCADE,
   "LikeDate" timestamp with time zone NOT NULL DEFAULT now(),

--- a/DBInit/0-db-init.sql
+++ b/DBInit/0-db-init.sql
@@ -45,8 +45,7 @@ CREATE TABLE public."Users" (
   "Email" character varying(128),
   "PasswordHash" character varying(128) NOT NULL,
   "RoleId" uuid NOT NULL,
-  FOREIGN KEY ("RoleId") REFERENCES public."Roles" ("Id")
-  MATCH SIMPLE ON UPDATE NO ACTION ON DELETE RESTRICT
+  FOREIGN KEY ("RoleId") REFERENCES public."Roles" ("Id") ON DELETE RESTRICT
 );
 CREATE INDEX "fki_Users_RoleId_fkey" ON public."Users" USING btree ("RoleId");
 CREATE UNIQUE INDEX users_unique_email ON public."Users" USING btree ("Email");
@@ -58,8 +57,7 @@ CREATE TABLE public."Paragraphs" (
   "ParagraphText" text NOT NULL,
   "SerialNumber" integer NOT NULL,
   "IsSubtitle" boolean NOT NULL,
-  FOREIGN KEY ("ArticleId") REFERENCES public."Articles" ("Id")
-  MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE
+  FOREIGN KEY ("ArticleId") REFERENCES public."Articles" ("Id") ON DELETE CASCADE
 );
 CREATE INDEX "fki_Paragraphs_ArticleId_fkey" ON public."Paragraphs" USING btree ("ArticleId");
 
@@ -67,7 +65,22 @@ CREATE TABLE public."Doppelgangers" (
   "Id" uuid PRIMARY KEY NOT NULL,
   "MushroomId" uuid NOT NULL,
   "DoppelgangerName" character varying(128) NOT NULL,
-  FOREIGN KEY ("MushroomId") REFERENCES public."Mushrooms" ("Id")
-  MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE
+  FOREIGN KEY ("MushroomId") REFERENCES public."Mushrooms" ("Id") ON DELETE CASCADE
 );
 CREATE INDEX "fki_Doppelgangers_MushroomId_fkey" ON public."Doppelgangers" USING btree ("MushroomId");
+
+CREATE TABLE public."ArticleLikes" (
+  "Id" serial primary key,
+  "ArticleId" uuid NOT NULL REFERENCES public."Articles" ("Id") ON DELETE CASCADE,
+  "UserId" uuid NOT NULL REFERENCES public."Users" ("Id") ON DELETE CASCADE,
+  "LikeDate" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT article_likes_unique_user_article UNIQUE ("ArticleId", "UserId")
+);
+
+CREATE TABLE public."MushroomLikes" (
+  "Id" serial primary key,
+  "MushroomId" uuid NOT NULL REFERENCES public."Mushrooms" ("Id") ON DELETE CASCADE,
+  "UserId" uuid NOT NULL REFERENCES public."Users" ("Id") ON DELETE CASCADE,
+  "LikeDate" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT mushroom_likes_unique_user_mushroom UNIQUE ("MushroomId", "UserId")
+);

--- a/DBInit/1-mock-data.sql
+++ b/DBInit/1-mock-data.sql
@@ -53,27 +53,41 @@ VALUES ('3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3
         'Никогда не собирайте грибы, в которых вы не уверены.', 1, false),
        ('5c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f', '1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', '1. Бледная поганка', 0, true);
 
--- Insert article likes (теперь без указания Id, так как он serial)
-INSERT INTO public."ArticleLikes" ("ArticleId", "UserId", "LikeDate") VALUES
+-- Insert article likes
+INSERT INTO public."ArticleLikes" ("Id", "ArticleId", "UserId", "LikeDate")
+VALUES
 -- Лайки для статьи "Как отличить съедобные грибы от ядовитых"
-('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-15 10:15:00+03'), -- админ
-('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-15 11:30:00+03'), -- редактор
-('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-16 09:45:00+03'), -- пользователь
+('9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+ '2023-08-15 10:15:00+03'), -- админ
+('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15',
+ '2023-08-15 11:30:00+03'), -- редактор
+('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16',
+ '2023-08-16 09:45:00+03'), -- пользователь
 
 -- Лайки для статьи "Топ-5 самых опасных грибов России"
-('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-09-01 15:00:00+03'), -- админ
-('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-09-02 12:20:00+03'); -- пользователь
+('2f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c', '1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+ '2023-09-01 15:00:00+03'), -- админ
+('3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d', '1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16',
+ '2023-09-02 12:20:00+03');
+-- пользователь
 
--- Insert mushroom likes (также без указания Id)
-INSERT INTO public."MushroomLikes" ("MushroomId", "UserId", "LikeDate") VALUES
+-- Insert mushroom likes
+INSERT INTO public."MushroomLikes" ("Id", "MushroomId", "UserId", "LikeDate")
+VALUES
 -- Лайки для Белого гриба
-('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-10 08:00:00+03'), -- админ
-('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-10 09:15:00+03'), -- редактор
-('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-11 10:30:00+03'), -- пользователь
+('4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+ '2023-08-10 08:00:00+03'), -- админ
+('5c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15',
+ '2023-08-10 09:15:00+03'), -- редактор
+('6d7e8f9a-0b1c-2d3e-4f5a-6b7c8d9e0f1a', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16',
+ '2023-08-11 10:30:00+03'), -- пользователь
 
 -- Лайки для Мухомора красного
-('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-12 11:45:00+03'), -- редактор
-('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-13 12:00:00+03'), -- пользователь
+('7e8f9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b', '2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15',
+ '2023-08-12 11:45:00+03'), -- редактор
+('8f9a0b1c-2d3e-4f5a-6b7c-8d9e0f1a2b3c', '2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16',
+ '2023-08-13 12:00:00+03'), -- пользователь
 
 -- Лайки для Бледной поганки
-('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-14 13:15:00+03'); -- админ
+('9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d', '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+ '2023-08-14 13:15:00+03'); -- админ

--- a/DBInit/1-mock-data.sql
+++ b/DBInit/1-mock-data.sql
@@ -1,35 +1,79 @@
 -- Insert roles
-INSERT INTO public."Roles" ("Id", "Name", "AccessLevel") VALUES
-('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Admin', 0),
-('b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12', 'Editor', 19),
-('c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13', 'User', 20);
+INSERT INTO public."Roles" ("Id", "Name", "AccessLevel")
+VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Admin', 0),
+       ('b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12', 'Editor', 19),
+       ('c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13', 'User', 20);
 
 -- Insert users
-INSERT INTO public."Users" ("Id", "Username", "Email", "PasswordHash", "RoleId") VALUES
+INSERT INTO public."Users" ("Id", "Username", "Email", "PasswordHash", "RoleId")
+VALUES
 -- Пароль: Fungi123!
-('d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', 'admin_user', 'admin@mushroomproject.com', '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
-('e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', 'editor_user', 'editor@mushroomproject.com', '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'),
-('f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', 'regular_user', 'user@mushroomproject.com', '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13');
+('d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', 'admin_user', 'admin@mushroomproject.com',
+ '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+('e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', 'editor_user', 'editor@mushroomproject.com',
+ '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'),
+('f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', 'regular_user', 'user@mushroomproject.com',
+ '$2a$11$zA5O21EK4ncH2AOyaY/aoOnN8OXUIhz5m5tVGuhhTybxeTjLiohoq', 'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13');
 
 -- Insert mushrooms
-INSERT INTO public."Mushrooms" ("Id", "Name", "SynonymousName", "LatinName", "Family", "RedBook", "Eatable", "HasStem", "StemSizeFrom", "StemSizeTo", "StemType", "StemColor", "CapType", "CapColor", "CapUndersideType", "Description", "HeaderPhotoLink", "ExtraPhotoLinks") VALUES
-('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Белый гриб', 'Боровик', 'Boletus edulis', 'Болетовые', false, 'Съедобный', true, 8, 25, 'цилиндрический', 'беловатый', 'выпуклый', 'коричневый', 'трубчатый', 'Белый гриб - один из самых ценных съедобных грибов.', 'https://i.imgur.com/white_mushroom.jpg', 'https://i.imgur.com/white_mushroom1.jpg;https://i.imgur.com/white_mushroom2.jpg'),
-('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'Мухомор красный', NULL, 'Amanita muscaria', 'Аманитовые', false, 'Несъедобный', true, 10, 20, 'цилиндрический', 'белый', 'полушаровидный', 'красный', 'пластинчатый', 'Яркий гриб с красной шляпкой и белыми хлопьями.', 'https://i.imgur.com/fly_agaric.jpg', 'https://i.imgur.com/fly_agaric1.jpg'),
-('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'Бледная поганка', NULL, 'Amanita phalloides', 'Аманитовые', true, 'Несъедобный', true, 8, 15, 'цилиндрический', 'белый', 'колокольчатый', 'зеленоватый', 'пластинчатый', 'Один из самых ядовитых грибов.', 'https://i.imgur.com/death_cap.jpg', NULL);
+INSERT INTO public."Mushrooms" ("Id", "Name", "SynonymousName", "LatinName", "Family", "RedBook", "Eatable", "HasStem",
+                                "StemSizeFrom", "StemSizeTo", "StemType", "StemColor", "CapType", "CapColor",
+                                "CapUndersideType", "Description", "HeaderPhotoLink", "ExtraPhotoLinks")
+VALUES ('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Белый гриб', 'Боровик', 'Boletus edulis', 'Болетовые', false,
+        'Съедобный', true, 8, 25, 'цилиндрический', 'беловатый', 'выпуклый', 'коричневый', 'трубчатый',
+        'Белый гриб - один из самых ценных съедобных грибов.', 'https://i.imgur.com/white_mushroom.jpg',
+        'https://i.imgur.com/white_mushroom1.jpg;https://i.imgur.com/white_mushroom2.jpg'),
+       ('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'Мухомор красный', NULL, 'Amanita muscaria', 'Аманитовые', false,
+        'Несъедобный', true, 10, 20, 'цилиндрический', 'белый', 'полушаровидный', 'красный', 'пластинчатый',
+        'Яркий гриб с красной шляпкой и белыми хлопьями.', 'https://i.imgur.com/fly_agaric.jpg',
+        'https://i.imgur.com/fly_agaric1.jpg'),
+       ('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'Бледная поганка', NULL, 'Amanita phalloides', 'Аманитовые', true,
+        'Несъедобный', true, 8, 15, 'цилиндрический', 'белый', 'колокольчатый', 'зеленоватый', 'пластинчатый',
+        'Один из самых ядовитых грибов.', 'https://i.imgur.com/death_cap.jpg', NULL);
 
 -- Insert doppelgangers
-INSERT INTO public."Doppelgangers" ("Id", "MushroomId", "DoppelgangerName") VALUES
-('6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Желчный гриб'),
-('7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Сатанинский гриб'),
-('8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e', '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'Шампиньон');
+INSERT INTO public."Doppelgangers" ("Id", "MushroomId", "DoppelgangerName")
+VALUES ('6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Желчный гриб'),
+       ('7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'Сатанинский гриб'),
+       ('8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e', '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'Шампиньон');
 
 -- Insert articles
-INSERT INTO public."Articles" ("Id", "Title", "PublishDate", "AuthorString", "HeaderPhotoLink", "ExtraPhotoLinks") VALUES
-('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'Как отличить съедобные грибы от ядовитых', '2023-08-15 10:00:00+03', 'Иван Петров', 'https://i.imgur.com/safety.jpg', 'https://i.imgur.com/safety1.jpg;https://i.imgur.com/safety2.jpg'),
-('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'Топ-5 самых опасных грибов России', '2023-09-01 14:30:00+03', 'Мария Сидорова', 'https://i.imgur.com/dangerous.jpg', NULL);
+INSERT INTO public."Articles" ("Id", "Title", "PublishDate", "AuthorString", "HeaderPhotoLink", "ExtraPhotoLinks")
+VALUES ('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'Как отличить съедобные грибы от ядовитых', '2023-08-15 10:00:00+03',
+        'Иван Петров', 'https://i.imgur.com/safety.jpg',
+        'https://i.imgur.com/safety1.jpg;https://i.imgur.com/safety2.jpg'),
+       ('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'Топ-5 самых опасных грибов России', '2023-09-01 14:30:00+03',
+        'Мария Сидорова', 'https://i.imgur.com/dangerous.jpg', NULL);
 
 -- Insert paragraphs
-INSERT INTO public."Paragraphs" ("Id", "ArticleId", "ParagraphText", "SerialNumber", "IsSubtitle") VALUES
-('3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'Основные правила безопасности', 0, true),
-('4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'Никогда не собирайте грибы, в которых вы не уверены.', 1, false),
-('5c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f', '1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', '1. Бледная поганка', 0, true);
+INSERT INTO public."Paragraphs" ("Id", "ArticleId", "ParagraphText", "SerialNumber", "IsSubtitle")
+VALUES ('3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'Основные правила безопасности',
+        0, true),
+       ('4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e', '0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a',
+        'Никогда не собирайте грибы, в которых вы не уверены.', 1, false),
+       ('5c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f', '1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', '1. Бледная поганка', 0, true);
+
+-- Insert article likes (теперь без указания Id, так как он serial)
+INSERT INTO public."ArticleLikes" ("ArticleId", "UserId", "LikeDate") VALUES
+-- Лайки для статьи "Как отличить съедобные грибы от ядовитых"
+('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-15 10:15:00+03'), -- админ
+('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-15 11:30:00+03'), -- редактор
+('0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-16 09:45:00+03'), -- пользователь
+
+-- Лайки для статьи "Топ-5 самых опасных грибов России"
+('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-09-01 15:00:00+03'), -- админ
+('1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-09-02 12:20:00+03'); -- пользователь
+
+-- Insert mushroom likes (также без указания Id)
+INSERT INTO public."MushroomLikes" ("MushroomId", "UserId", "LikeDate") VALUES
+-- Лайки для Белого гриба
+('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-10 08:00:00+03'), -- админ
+('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-10 09:15:00+03'), -- редактор
+('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-11 10:30:00+03'), -- пользователь
+
+-- Лайки для Мухомора красного
+('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15', '2023-08-12 11:45:00+03'), -- редактор
+('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16', '2023-08-13 12:00:00+03'), -- пользователь
+
+-- Лайки для Бледной поганки
+('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', '2023-08-14 13:15:00+03'); -- админ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,11 @@ services:
       POSTGRES_DB: FungiDB
       POSTGRES_USER: fungi
       POSTGRES_PASSWORD: fungi
-      PGPORT: 5531
     volumes:
       - pg_fungi_data:/var/lib/postgresql/data
       - ./DBInit:/docker-entrypoint-initdb.d  
     ports:
-      - "5531:5531"
+      - "5531:5432"
 
   fungi-backend:
     container_name: fungi-backend


### PR DESCRIPTION
добавлены две таблицы + датасидинг
поправлена работа с бд в докере
для лайков три меотда: ToggleLikeAsync - лайк / убрать лайк; GetLikesCountAsync - получить кол-во лайков; HasUserLikedAsync - лайкнул ли юзер (для фронта мб будет удобно в качестве отображения) (ToggleLikeAsync  и  HasUserLikedAsync берут ид пользователя из jwt)